### PR TITLE
Bugfix: don't inline non-existent element

### DIFF
--- a/technical.js
+++ b/technical.js
@@ -229,7 +229,9 @@ function tab(tabby) {
 	{
 	
 		gameData.isOptionsOpen = 0
-		document.getElementById(tabby).style.display = "inline-block"
+		tabbyElem = document.getElementById(tabby)
+		if (tabbyElem)
+			tabbyElem.style.display = "inline-block"
   
 	}
 


### PR DESCRIPTION
This fixes a bug when the shop isn't available yet at startup.  (Prevent trying to write to an non-existed DOM element.)

Fixes this error message in the console:

    Uncaught TypeError: Cannot read property 'style' of null
        at tab (technical.js?v=56:232)
        at technical.js?v=56:197

Caused by:

    document.getElementById(tabby)

returning null.